### PR TITLE
update snakemake to v7.15.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     needs: bump-version
     name: Update docs
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, 'chore:')"
+    if: "contains(github.event.head_commit.message, 'chore(main):')"
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           git config --global user.name "Github Actions"
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 12
 

--- a/env.yml
+++ b/env.yml
@@ -9,7 +9,7 @@ dependencies:
   - python=3.10
   - mamba>=0.17
   - drmaa==0.7.9
-  - snakemake=7.12
+  - snakemake==7.15.2
   - biopython==1.79
   - pandas==1.4.2
   - openpyxl==3.0.9

--- a/mamba-env.yaml
+++ b/mamba-env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.10
   - mamba>=0.17
   - drmaa==0.7.9
-  - snakemake=7.12
+  - snakemake==7.15.2
   - biopython==1.79
   - pandas==1.4.2
   - openpyxl==3.0.9

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,13 @@ Please make sure SnakeMake is installed properly before installing ViroConstrict
 """
     )
 
-if vv.parse(snakemake.__version__) < vv.parse("7.3"):
+if vv.parse(snakemake.__version__) < vv.parse("7.15.2"):
     sys.exit(
         f"""
 The installed SnakeMake version is older than the minimally required version:
 
 Installed SnakeMake version: {snakemake.__version__}
-Required SnakeMake version: 7.3 or later
+Required SnakeMake version: 7.15.2 or later
 
 Please update SnakeMake to a supported version and try again
 """


### PR DESCRIPTION
Update snakemake to version 7.15.2 for dependency compatibility with tabulate v0.9

Snakemake v7.15.2 is now also set as a minimal version in setup.py