### PR TITLE
quick fix for NoneType Attribute error

### DIFF
--- a/ViroConstrictor/parser.py
+++ b/ViroConstrictor/parser.py
@@ -698,7 +698,7 @@ def ValidArgs(sysargs):
             None, args, GetSamples(args.input, args.platform)
         )
 
-    if df is not None:
+    if df is None:
         df = pd.DataFrame.from_dict(sampleinfo, orient="index")
     if not sampleinfo:
         sys.exit(1)

--- a/env.yml
+++ b/env.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml==6.0
   - urllib3>=1.26
   - fpdf2==2.5.1
-  - rich=12.5
+  - rich=13
   - pip
   - pip:
     - AminoExtract


### PR DESCRIPTION
Fix for a NoneType Attribute error when all required information is passed to ViroConstrictor through the commandline options instead of a samplesheet.