### PR TITLE
Enforce absolute paths in samplesheets and workaround for protobuf error

### DIFF
--- a/ViroConstrictor/__main__.py
+++ b/ViroConstrictor/__main__.py
@@ -68,17 +68,21 @@ This applies to the following samples:\n{''.join(samples)}"""
 
     p_fallbackwarning_df = sample_info_df.loc[sample_info_df["PRESET_SCORE"] == 0.0]
     targets, presets = (
-        list(x)
-        for x in (
-            zip(
-                *zip_longest(
-                    list(set(p_fallbackwarning_df["VIRUS"].tolist())),
-                    list(set(p_fallbackwarning_df["PRESET"].tolist())),
-                    fillvalue="DEFAULT",
+        (
+            list(x)
+            for x in (
+                zip(
+                    *zip_longest(
+                        list(set(p_fallbackwarning_df["VIRUS"].tolist())),
+                        list(set(p_fallbackwarning_df["PRESET"].tolist())),
+                        fillvalue="DEFAULT",
+                    )
                 )
             )
         )
-    ) if p_fallbackwarning_df.shape[0] > 0 else ([], [])
+        if p_fallbackwarning_df.shape[0] > 0
+        else ([], [])
+    )
     for _input, _preset in zip(targets, presets):
         filtered_df = p_fallbackwarning_df.loc[
             (p_fallbackwarning_df["VIRUS"] == _input)

--- a/ViroConstrictor/logging.py
+++ b/ViroConstrictor/logging.py
@@ -257,6 +257,7 @@ def snakemake_logger(logfile: str) -> object:
         The function `snakemake_logger` returns a function object `log_handler`.
 
     """
+
     def log_handler(msg: dict) -> None:
         loglevel = msg.get("level")
         logmessage = msg.get("msg")

--- a/ViroConstrictor/parser.py
+++ b/ViroConstrictor/parser.py
@@ -326,7 +326,9 @@ class CLIparser:
         )
 
         optional_args.add_argument(
-            "--skip-updates", action="store_true", help="Skip the update check",
+            "--skip-updates",
+            action="store_true",
+            help="Skip the update check",
         )
 
         if not givenargs:

--- a/ViroConstrictor/parser.py
+++ b/ViroConstrictor/parser.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import re
 import sys
-from typing import Any, Hashable
+from typing import Any, Hashable, List
 
 import numpy as np
 import pandas as pd
@@ -326,9 +326,7 @@ class CLIparser:
         )
 
         optional_args.add_argument(
-            "--skip-updates",
-            action="store_true",
-            help="Skip the update check",
+            "--skip-updates", action="store_true", help="Skip the update check",
         )
 
         if not givenargs:
@@ -360,7 +358,7 @@ class CLIparser:
             req_cols = check_samplesheet_columns(df)
             if req_cols is False:
                 sys.exit(1)
-            df =  samplesheet_enforce_absolute_paths(df)
+            df = samplesheet_enforce_absolute_paths(df)
             if df.get("PRESET") is None:
                 df[["PRESET", "PRESET_SCORE"]] = df.apply(
                     lambda x: pd.Series(
@@ -550,7 +548,9 @@ def samplesheet_enforce_absolute_paths(df: pd.DataFrame) -> pd.DataFrame:
     columns_to_enforce: List[str] = ["PRIMERS", "FEATURES", "REFERENCE"]
     for column in columns_to_enforce:
         if column in df.columns:
-            df[column] = df[column].apply(lambda x: os.path.abspath(os.path.expanduser(x)) if x != "NONE" else x)
+            df[column] = df[column].apply(
+                lambda x: os.path.abspath(os.path.expanduser(x)) if x != "NONE" else x
+            )
     return df
 
 
@@ -901,7 +901,9 @@ def args_to_df(args: argparse.Namespace, df: pd.DataFrame) -> pd.DataFrame:
     df["MATCH-REF"] = args.match_ref
     df["PRIMERS"] = os.path.abspath(args.primers) if args.primers != "NONE" else "NONE"
     df["REFERENCE"] = os.path.abspath(args.reference)
-    df["FEATURES"] = os.path.abspath(args.features) if args.features != "NONE" else "NONE"
+    df["FEATURES"] = (
+        os.path.abspath(args.features) if args.features != "NONE" else "NONE"
+    )
     df["MIN-COVERAGE"] = args.min_coverage
     df["PRIMER-MISMATCH-RATE"] = args.primer_mismatch_rate
     df[["PRESET", "PRESET_SCORE"]] = match_preset_name(args.target, args.presets)

--- a/env.yml
+++ b/env.yml
@@ -9,7 +9,7 @@ dependencies:
   - python>=3.10
   - mamba>=1.0.0
   - drmaa==0.7.9
-  - snakemake==7.25.*
+  - snakemake-minimal==7.25.*
   - biopython==1.81
   - pandas==2.0.*
   - openpyxl==3.1.*


### PR DESCRIPTION
Added function to enforce absolute paths in the samplesheet before its converted to a dictionary

Added a fix for the protobuf error that exists in the cloud api functions shipped with the main snakemake package (use only snakemake-minimal)