### PR TITLE
fix DI filtering in clipper script

### DIFF
--- a/ViroConstrictor/logging.py
+++ b/ViroConstrictor/logging.py
@@ -239,7 +239,8 @@ logmessage_strings_info: dict[str, Callable] = {
     "Nothing to be done (all requested files are present and up to date).": BaseLogMessage,
 }
 logmessage_suppressed_strings_warning: list[str] = [
-    "Your conda installation is not configured to use strict channel priorities."
+    "Your conda installation is not configured to use strict channel priorities.",
+    "Failed to download resource needed for report:"
 ]
 
 

--- a/ViroConstrictor/workflow/scripts/clipper.py
+++ b/ViroConstrictor/workflow/scripts/clipper.py
@@ -161,7 +161,7 @@ with flags.output as fileout:
     bamfile = pysam.AlignmentFile(flags.input, "rb", threads=flags.threads)
 
     reflength = bamfile.lengths[0]
-    minimal_read_length = int(flags.min_aligned_length)
+    minimal_read_length = int(reflength * flags.min_aligned_length)
     maximum_read_length = int(
         reflength if flags.max_aligned_length == 0 else flags.max_aligned_length
     )

--- a/build_local_containers.py
+++ b/build_local_containers.py
@@ -33,6 +33,8 @@ subprocess.run(
 )
 
 for file in glob.glob("./containers/*.sif"):
+    if os.path.exists(containerpath + "/" + file.split("/")[-1]):
+        os.remove(containerpath + "/" + file.split("/")[-1])
     print(file)
     shutil.move(file, containerpath) if containerpath else None
 for file in glob.glob("./containers/*.tar"):


### PR DESCRIPTION
- fixes the filtering of DI reads in Influenza experiments
- suppresses the snakemake report error existing in snakemake 7
- overwrites containers when using the local building of containers for dev purposes (doesn't affect production) 