### PR TITLE
Include extra regex pattern for Artic V5.4.2 primer scheme in `amplicon_covs.py`

### DIFF
--- a/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
+++ b/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
@@ -135,6 +135,8 @@ class PrimerNameParser:
             # Pattern 7: name_number-alt_direction (e.g., "MuV-NGS_19-alt22_LEFT")
             r"^([^_]+)_(\d+)-(alt\w*)_([^_]+)$",
             # Pattern 8: schemeName_ampliconNumber_direction_primerNumber (e.g., "SARS-CoV-2_12_RIGHT_0")
+            # PrimerNumber refers to the version of the primer, e.g., 0 for original, 1 for version 1, 2 for version 2, etc.
+            # primer pool information is not included in the primer name, but instead is included in column 5 of the BED file (1 or 2)
             r"^([^_]+)_(\d+)_([^_]+)_(\d+)$",
         ]
 

--- a/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
+++ b/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
@@ -134,6 +134,8 @@ class PrimerNameParser:
             r"^(.+)_(\d+)_(alt\w*)_([^_]+)$",
             # Pattern 7: name_number-alt_direction (e.g., "MuV-NGS_19-alt22_LEFT")
             r"^([^_]+)_(\d+)-(alt\w*)_([^_]+)$",
+            # Pattern 8: schemeName_ampliconNumber_direction_primerNumber (e.g., "SARS-CoV-2_12_RIGHT_0")
+            r"^([^_]+)_(\d+)_([^_]+)_(\d+)$",
         ]
 
     def parse(self, primer_name: str) -> PrimerInfo:

--- a/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
+++ b/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
@@ -137,7 +137,7 @@ class PrimerNameParser:
             # Pattern 8: schemeName_ampliconNumber_direction_primerNumber (e.g., "SARS-CoV-2_12_RIGHT_0")
             # PrimerNumber refers to the version of the primer, e.g., 0 for original, 1 for version 1, 2 for version 2, etc.
             # primer pool information is not included in the primer name, but instead is included in column 5 of the BED file (1 or 2)
-            r"^([^_]+)_(\d+)_([^_]+)_(\d+)$",
+            r"^([^_]+)_(\d+)_([^_]+)_(?:\d+)$",
         ]
 
     def parse(self, primer_name: str) -> PrimerInfo:

--- a/tests/unit/scripts/test_amplicon_covs.py
+++ b/tests/unit/scripts/test_amplicon_covs.py
@@ -4,15 +4,34 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+import pandas as pd
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT.joinpath("ViroConstrictor/workflow")))
-from ViroConstrictor.workflow.main.scripts.amplicon_covs import AmpliconCovs  # isort:skip
+from ViroConstrictor.workflow.main.scripts.amplicon_covs import (  # isort:skip
+    AmpliconCovs,
+    PrimerNameParser,
+    ReadDirection,
+)
 
 
 @contextmanager
 def temporarily_modify_file(file_path: Path, new_line: str) -> Iterator[None]:
-    """Context manager that temporarily modifies the contents of a file for testing purposes."""
+    """
+    Temporarily replace a file's contents and restore them on exit.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the file to modify.
+    new_line : str
+        New content to write to the file while inside the context.
+
+    Yields
+    ------
+    None
+        Control back to the context block. Original file contents are restored on exit.
+    """
     with open(file_path, "r", encoding="utf-8") as file:
         lines = file.readlines()
 
@@ -28,7 +47,18 @@ def temporarily_modify_file(file_path: Path, new_line: str) -> Iterator[None]:
 
 
 def test_amplicon_covs(tmp_path: Path) -> None:
-    """Test basic functionality of AmpliconCovs with valid input."""
+    """
+    Validate basic functionality of `AmpliconCovs` using sample BED and coverage files.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory fixture provided by pytest for output files.
+
+    Returns
+    -------
+    None
+    """
     input_file = PROJECT_ROOT / "tests" / "unit" / "data" / "ESIB_EQA_2024_SARS1_01_primers.bed"
     output_file = tmp_path / "ESIB_EQA_2024_SARS1_01_primers_output.csv"
     coverages_file = PROJECT_ROOT / "tests" / "unit" / "data" / "ESIB_EQA_2024_SARS1_01_coverage.tsv"
@@ -40,12 +70,19 @@ def test_amplicon_covs(tmp_path: Path) -> None:
     assert output_file.exists()
 
 
-def test_primer_name_validation(tmp_path: Path) -> None:
-    """Test validation of primer names - both valid and invalid formats."""
-    input_file = PROJECT_ROOT / "tests" / "unit" / "data" / "ESIB_EQA_2024_SARS1_01_primers.bed"
-    output_file = tmp_path / "test_output.csv"
-    coverages_file = PROJECT_ROOT / "tests" / "unit" / "data" / "ESIB_EQA_2024_SARS1_01_coverage.tsv"
-    key = "ESIB_EQA_2024_SARS1_01"
+def test_primer_name_validation() -> None:
+    """
+    Verify the `PrimerNameParser` accepts valid primer name formats and rejects invalid ones.
+
+    The test iterates over several example primer names and checks that parsing
+    either succeeds (returning an object with an integer `count`) or raises
+    a `ValueError` for invalid formats.
+
+    Returns
+    -------
+    None
+    """
+    parser = PrimerNameParser()
 
     # Test cases: (primer_name, should_succeed)
     test_cases = [
@@ -68,6 +105,7 @@ def test_primer_name_validation(tmp_path: Path) -> None:
         ("virus_strain_1_LEFT", True),
         ("virus_strain_1_alt_RIGHT", True),
         ("MuV-NGS_19-alt22_LEFT", True),
+        ("SARS-CoV-2_12_RIGHT_0", True),
         # Invalid primer names
         ("wrong_name", False),  # Missing required components
         ("ncov-2019_LEFT", False),  # Missing primer number
@@ -76,20 +114,281 @@ def test_primer_name_validation(tmp_path: Path) -> None:
     ]
 
     for primer_name, should_succeed in test_cases:
-        bed_line = f"NC_045512.2\t1\t100\t{primer_name}\t0\t+\n"
+        if should_succeed:
+            info = parser.parse(primer_name)
+            assert info.original_string.lstrip(">") in primer_name
+            assert isinstance(info.count, int)
+        else:
+            with pytest.raises(ValueError) as exc_info:
+                parser.parse(primer_name)
 
-        with temporarily_modify_file(input_file, bed_line):
-            amplicon_covs = AmpliconCovs(input=input_file, output=output_file, key=key, coverages=coverages_file)
+            error_msg = str(exc_info.value)
+            assert any(
+                keyword in error_msg for keyword in ["Primer", "Unrecognized read direction", "does not match expected formats"]
+            ), f"Unexpected error message for {primer_name}: {error_msg}"
 
-            if should_succeed:
-                amplicon_covs.run()
-                assert output_file.exists(), f"Failed for valid primer name: {primer_name}"
-                output_file.unlink()  # Clean up for next iteration
-            else:
-                with pytest.raises(ValueError) as exc_info:
-                    amplicon_covs.run()
 
-                error_msg = str(exc_info.value)
-                assert any(
-                    keyword in error_msg for keyword in ["Primer", "Unrecognized read direction"]
-                ), f"Unexpected error message for {primer_name}: {error_msg}"
+def _write_bed(tmp_path: Path, lines: list[str]) -> Path:
+    """
+    Write primer BED lines to a file in the provided temporary directory.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to write the file into.
+    lines : list[str]
+        Lines to write to the BED file (each including trailing newline).
+
+    Returns
+    -------
+    Path
+        Path to the written BED file.
+    """
+
+    bed_path = tmp_path / "primers.bed"
+    bed_path.write_text("".join(lines), encoding="utf-8")
+    return bed_path
+
+
+def _write_coverage(tmp_path: Path, values: list[int]) -> Path:
+    """
+    Create a simple coverage TSV file with one coverage value per line.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to write the coverage file into.
+    values : list[int]
+        Coverage values to write; each value is written on its own row with
+        a 1-based index in the first column.
+
+    Returns
+    -------
+    Path
+        Path to the written coverage TSV file.
+    """
+
+    cov_path = tmp_path / "coverage.tsv"
+    lines = [f"{idx + 1}\t{value}\n" for idx, value in enumerate(values)]
+    cov_path.write_text("".join(lines), encoding="utf-8")
+    return cov_path
+
+
+def test_open_tsv_file_empty(tmp_path: Path) -> None:
+    """
+    Ensure `_open_tsv_file` returns an empty DataFrame for an empty file.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Pytest temporary directory fixture.
+
+    Returns
+    -------
+    None
+    """
+
+    empty_file = tmp_path / "empty.tsv"
+    empty_file.write_text("", encoding="utf-8")
+
+    df = AmpliconCovs._open_tsv_file(empty_file)
+
+    assert df.empty
+
+
+def test_open_tsv_file_nan_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Verify that `_open_tsv_file` raises a `ValueError` when the file contains NaN.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest fixture for temporarily patching attributes.
+    tmp_path : Path
+        Temporary directory fixture for creating the bad TSV file.
+
+    Returns
+    -------
+    None
+    """
+
+    bad_file = tmp_path / "bad.tsv"
+    bad_file.write_text("1\t10\n", encoding="utf-8")
+    bad_df = pd.DataFrame([[1, float("nan")]])
+
+    def _fake_read_csv(*_args: object, **_kwargs: object) -> pd.DataFrame:
+        return bad_df
+
+    monkeypatch.setattr(pd, "read_csv", _fake_read_csv)
+
+    with pytest.raises(ValueError, match="contains NaN values"):
+        AmpliconCovs._open_tsv_file(bad_file)
+
+
+def test_calculate_amplicon_start_end_two_amplicons(tmp_path: Path) -> None:
+    """
+    Calculate start/end coordinates for two amplicons from paired primer entries.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory fixture for creating a temporary BED file.
+
+    Returns
+    -------
+    None
+    """
+
+    bed_lines = [
+        "NC_045512.2\t10\t20\tvirus_1_LEFT\t0\t+\n",
+        "NC_045512.2\t80\t90\tvirus_1_RIGHT\t0\t-\n",
+        "NC_045512.2\t100\t110\tvirus_2_LEFT\t0\t+\n",
+        "NC_045512.2\t170\t180\tvirus_2_RIGHT\t0\t-\n",
+    ]
+    bed_path = _write_bed(tmp_path, bed_lines)
+    primers = AmpliconCovs._open_tsv_file(bed_path)
+    covs = AmpliconCovs(input=bed_path, coverages=bed_path, key="sample", output=bed_path)
+    primers = covs._split_primer_names(primers)
+
+    amplicon_sizes = covs._calculate_amplicon_start_end(primers)
+
+    first = amplicon_sizes.loc[amplicon_sizes["amplicon_number"] == 1].iloc[0]
+    second = amplicon_sizes.loc[amplicon_sizes["amplicon_number"] == 2].iloc[0]
+    assert (first["start"], first["end"]) == (20, 100)
+    assert (second["start"], second["end"]) == (90, 170)
+
+
+def test_calculate_amplicon_start_end_invalid_raises(tmp_path: Path) -> None:
+    """
+    Ensure `_calculate_amplicon_start_end` raises for overlapping/invalid primer pairs.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory fixture for creating a temporary BED file.
+
+    Returns
+    -------
+    None
+    """
+
+    bed_lines = [
+        "NC_045512.2\t10\t100\tvirus_1_LEFT\t0\t+\n",
+        "NC_045512.2\t50\t60\tvirus_1_RIGHT\t0\t-\n",
+    ]
+    bed_path = _write_bed(tmp_path, bed_lines)
+    primers = AmpliconCovs._open_tsv_file(bed_path)
+    covs = AmpliconCovs(input=bed_path, coverages=bed_path, key="sample", output=bed_path)
+    primers = covs._split_primer_names(primers)
+
+    with pytest.raises(ValueError, match="Invalid amplicon"):
+        covs._calculate_amplicon_start_end(primers)
+
+
+def test_calculate_mean_coverage() -> None:
+    """
+    Validate mean coverage calculation over a given start/end interval.
+
+    Returns
+    -------
+    None
+    """
+
+    coverages = AmpliconCovs._open_tsv_file(
+        Path(__file__).resolve().parents[3] / "tests" / "unit" / "data" / "ESIB_EQA_2024_SARS1_01_coverage.tsv",
+        index_col=0,
+    )
+    input_array = pd.Series({"start": 2, "end": 4})
+    mean_cov = AmpliconCovs._calculate_mean_coverage(input_array, coverages)
+
+    assert mean_cov == round(float(coverages.iloc[1:4].mean().values[0]), 2)
+
+
+def test_create_amplicon_names_list(tmp_path: Path) -> None:
+    """
+    Create normalized amplicon name list from primer entries (zero-padded numbers).
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory fixture for creating the BED file used in the test.
+
+    Returns
+    -------
+    None
+    """
+
+    bed_lines = [
+        "NC_045512.2\t10\t20\tvirus_1_LEFT\t0\t+\n",
+        "NC_045512.2\t80\t90\tvirus_12_RIGHT\t0\t-\n",
+    ]
+    bed_path = _write_bed(tmp_path, bed_lines)
+    primers = AmpliconCovs._open_tsv_file(bed_path)
+    covs = AmpliconCovs(input=bed_path, coverages=bed_path, key="sample", output=bed_path)
+    primers = covs._split_primer_names(primers)
+
+    amplicon_names = covs._create_amplicon_names_list(primers)
+
+    assert amplicon_names == ["virus_001", "virus_012"]
+
+
+def test_amplicon_covs_empty_primers(tmp_path: Path) -> None:
+    """
+    Run `AmpliconCovs` with an empty primer BED file to ensure output is produced.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory fixture for creating input and output files.
+
+    Returns
+    -------
+    None
+    """
+
+    bed_path = tmp_path / "empty.bed"
+    bed_path.write_text("", encoding="utf-8")
+    cov_path = _write_coverage(tmp_path, [10, 20, 30])
+    output_file = tmp_path / "output.csv"
+
+    covs = AmpliconCovs(input=bed_path, coverages=cov_path, key="sample1", output=output_file)
+    covs.run()
+
+    assert output_file.exists()
+    assert "sample1" in output_file.read_text(encoding="utf-8")
+
+
+def test_primer_name_parser_fallback_errors() -> None:
+    """
+    Confirm `PrimerNameParser` raises `ValueError` for inputs that don't match any
+    known primer name formats.
+
+    Returns
+    -------
+    None
+    """
+
+    parser = PrimerNameParser()
+
+    with pytest.raises(ValueError, match="does not match expected formats"):
+        parser.parse("bad")
+
+    with pytest.raises(ValueError, match="does not match expected formats"):
+        parser.parse("ncov-2019_1")
+
+
+def test_read_direction_from_string() -> None:
+    """
+    Verify `ReadDirection.from_string` parses common direction labels and
+    raises for unrecognized values.
+
+    Returns
+    -------
+    None
+    """
+
+    assert ReadDirection.from_string("LEFT") == ReadDirection.FORWARD
+    assert ReadDirection.from_string("reverse") == ReadDirection.REVERSE
+
+    with pytest.raises(ValueError, match="Unrecognized read direction"):
+        ReadDirection.from_string("sideways")


### PR DESCRIPTION
Added a new regular expression pattern to support primer names in the format `schemeName_ampliconNumber_direction_primerNumber` (e.g., `SARS-CoV-2_12_RIGHT_0`).