### PR TITLE
Change the self updater process to no longer use the mamba api

### DIFF
--- a/ViroConstrictor/update.py
+++ b/ViroConstrictor/update.py
@@ -21,6 +21,7 @@ import packaging.version
 from ViroConstrictor import __prog__, __version__
 from ViroConstrictor.logging import log
 from ViroConstrictor.userprofile import AskPrompts
+from urllib.parse import urlparse
 
 api_url = f"https://api.anaconda.org/release/bioconda/{__prog__.lower()}/latest"
 
@@ -40,6 +41,11 @@ def fetch_online_metadata() -> dict[str, Any] | None:
         error occurs.
     """
     try:
+        parsed = urlparse(api_url)
+        if parsed.scheme not in ("http", "https"):
+            log.warning(f"Refusing to open URL with unsupported scheme: {parsed.scheme}")
+            return None
+
         online_metadata = request.urlopen(api_url, timeout=60)
     except Exception as e:
         log.warning("Unable to connect to Anaconda API\n" f"{e}")

--- a/ViroConstrictor/update.py
+++ b/ViroConstrictor/update.py
@@ -325,7 +325,7 @@ There's a new version of ViroConstrictor available.
 
 Current version: [bold red]{local_version}[/bold red]
 Latest version: [bold green]{online_version}[/bold green]\n""",
-            "Do you want to update? [yes/no] ",
+            "Do you want to update? \[yes/no] ",
             ["yes", "no"],
             fixedchoices=True,
         )

--- a/ViroConstrictor/update.py
+++ b/ViroConstrictor/update.py
@@ -18,28 +18,9 @@ from ViroConstrictor.userprofile import AskPrompts
 repo_channels = ("bioconda", "conda-forge")
 api_url = f"https://api.anaconda.org/release/bioconda/{__prog__.lower()}/latest"
 
+#TODO: current implementation contains a lot of code duplication. We should refactor this to avoid that but it is acceptable for the current release. Target release for fixing this is 1.7.0
 
-@contextlib.contextmanager
-def silence_stdout_stderr():
-    """
-    This function temporarily redirects stdout and stderr to a null device to silence them.
-    """
-    sderr_fd = sys.stderr.fileno()
-    sdout_fd = sys.stdout.fileno()
-    orig_stderr_fd = os.dup(sderr_fd)
-    orig_stdout_fd = os.dup(sdout_fd)
-    null_fd = os.open(os.devnull, os.O_WRONLY)
-    os.dup2(null_fd, sdout_fd)
-    os.dup2(null_fd, sderr_fd)
-    try:
-        yield
-    finally:
-        os.dup2(orig_stdout_fd, sdout_fd)
-        os.dup2(orig_stderr_fd, sderr_fd)
-        os.close(null_fd)
-        os.close(orig_stderr_fd)
-        os.close(orig_stdout_fd)
-
+#TODO: Current implementation is too complex with one huge updating method. This should be fixed in a future release, but acceptable for now. Target release for fixiing this is 1.7.0
 
 def fetch_online_metadata() -> dict[str, Any] | None:
     """This function fetches online metadata from the Anaconda API URL and returns it as a dictionary, or returns

--- a/ViroConstrictor/update.py
+++ b/ViroConstrictor/update.py
@@ -140,7 +140,7 @@ def update(sysargs: list[str], conf: configparser.ConfigParser) -> None:
 
             if online_version is not None and (local_version < online_version):
                 log.info(f"Updating ViroConstrictor to latest version: [bold yellow]{online_version}[/bold yellow]")
-                update_succesfull = False
+                update_successful = False
                 try:
                     # Always use mamba/conda for updates
                     # First, uninstall any pip-installed version to avoid conflicts
@@ -186,7 +186,7 @@ def update(sysargs: list[str], conf: configparser.ConfigParser) -> None:
                         else:
                             log.error("Conda/mamba update command failed but did not produce any error output.")
 
-                    update_succesfull = result.returncode == 0
+                    update_successful = result.returncode == 0
                 except Exception as e:
                     log.error(
                         f"ViroConstrictor update process to version [bold yellow]{online_version}[/bold yellow] failed at package solver stage.\n"
@@ -196,7 +196,7 @@ def update(sysargs: list[str], conf: configparser.ConfigParser) -> None:
 
                     log.warning(f"Continuing with current version: [bold red]{local_version}[/bold red]")
                     return
-                if update_succesfull:
+                if update_successful:
                     post_install(sysargs, online_version)
                 else:
                     log.error(
@@ -229,7 +229,7 @@ Latest version: [bold green]{online_version}[/bold green]\n""",
             ):
                 log.info(f"Updating ViroConstrictor to latest version: [bold yellow]{online_version}[/bold yellow]")
 
-                update_succesfull = False
+                update_successful = False
                 try:
                     # Always use mamba/conda for updates
                     # First, uninstall any pip-installed version to avoid conflicts
@@ -266,15 +266,15 @@ Latest version: [bold green]{online_version}[/bold green]\n""",
 
                     result = subprocess.run(update_cmd, capture_output=True, text=True, check=False)
 
-                    update_succesfull = result.returncode == 0
+                    update_successful = result.returncode == 0
                 except Exception:
-                    update_succesfull = False
+                    update_successful = False
 
                     log.error(
                         f"ViroConstrictor update process to version [bold yellow]{online_version}[/bold yellow] failed at package solver stage.\nThis might indicate that a new version of ViroConstrictor is uploaded to bioconda but download-servers are not ready yet.\nPlease try again later."
                     )
                     log.warning(f"Continuing with current version: [bold red]{local_version}[/bold red]")
-                if update_succesfull:
+                if update_successful:
                     post_install(sysargs, online_version)
                 else:
                     log.error(

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,15 +1,31 @@
 import configparser
 import json
 import os
-import subprocess
-import sys
-from unittest.mock import MagicMock, Mock, mock_open, patch
-from urllib.error import URLError
+from unittest.mock import Mock, patch
 
 import packaging.version
 import pytest
 
-from ViroConstrictor.update import fetch_online_metadata, post_install, update
+from ViroConstrictor.update import (
+    _build_update_cmd,
+    _get_online_version,
+    _handle_update_result,
+    _prompt_for_update,
+    _run_update,
+    _update_if_available,
+    fetch_online_metadata,
+    post_install,
+    update,
+)
+
+
+def _build_config(auto_update: str = "no", ask_for_update: str = "no") -> configparser.ConfigParser:
+    conf = configparser.ConfigParser()
+    conf["GENERAL"] = {
+        "auto_update": auto_update,
+        "ask_for_update": ask_for_update,
+    }
+    return conf
 
 
 class TestFetchOnlineMetadata:
@@ -31,7 +47,7 @@ class TestFetchOnlineMetadata:
     @patch("ViroConstrictor.update.log")
     def test_fetch_online_metadata_connection_error(self, mock_log, mock_urlopen):
         """Test metadata fetch with connection error."""
-        mock_urlopen.side_effect = URLError("Connection failed")
+        mock_urlopen.side_effect = Exception("Connection failed")
 
         result = fetch_online_metadata()
 
@@ -54,234 +70,227 @@ class TestFetchOnlineMetadata:
 class TestPostInstall:
     """Test the post_install function."""
 
-    @patch("ViroConstrictor.update.subprocess.run")
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update.os.execv")
+    @patch("ViroConstrictor.update.shutil.which")
     @patch("ViroConstrictor.update.sys.exit")
-    @patch("ViroConstrictor.update.print")
-    def test_post_install_execution(self, mock_print, mock_exit, mock_subprocess):
+    def test_post_install_execution(self, mock_exit, mock_which, mock_execv, mock_log):
         """Test post-install execution flow."""
         sysargs = ["viroconstrictor", "--input", "data/"]
         version = packaging.version.parse("2.0.0")
+        mock_which.return_value = "/opt/conda/bin/viroconstrictor"
 
         post_install(sysargs, version)
 
-        mock_print.assert_called_once()
-        assert "ViroConstrictor updated to version" in mock_print.call_args[0][0]
-        assert "2.0.0" in mock_print.call_args[0][0]
-        mock_subprocess.assert_called_once_with(sysargs)
-        mock_exit.assert_called_once_with(0)
+        mock_log.info.assert_called_once_with("ViroConstrictor updated to version [bold yellow]2.0.0[/bold yellow]")
+        mock_execv.assert_called_once_with(
+            "/opt/conda/bin/viroconstrictor",
+            ["/opt/conda/bin/viroconstrictor", "--input", "data/"],
+        )
+        mock_exit.assert_not_called()
+
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update.os.execv")
+    @patch("ViroConstrictor.update.shutil.which")
+    def test_post_install_missing_binary(self, mock_which, mock_execv, mock_log):
+        """Test post-install exits when executable is missing."""
+        mock_which.return_value = None
+
+        with pytest.raises(SystemExit):
+            post_install(["viroconstrictor"], packaging.version.parse("2.0.0"))
+
+        mock_log.error.assert_called_once_with("Could not find viroconstrictor executable after update")
+        mock_execv.assert_not_called()
+
+
+class TestHelperFunctions:
+    """Test update helper functions."""
+
+    @patch("ViroConstrictor.update.shutil.which")
+    def test_build_update_cmd_prefers_mamba(self, mock_which):
+        """Test update command prefers mamba when available."""
+        mock_which.return_value = "/usr/bin/mamba"
+
+        cmd = _build_update_cmd(packaging.version.parse("2.0.0"), "/opt/conda")
+
+        assert cmd[0] == "mamba"
+        assert "viroconstrictor=2.0.0" in cmd
+
+    @patch("ViroConstrictor.update.shutil.which")
+    def test_build_update_cmd_falls_back_to_conda(self, mock_which):
+        """Test update command falls back to conda when mamba is unavailable."""
+        mock_which.return_value = None
+
+        cmd = _build_update_cmd(packaging.version.parse("2.0.0"), "/opt/conda")
+
+        assert cmd[0] == "conda"
+
+    @patch("ViroConstrictor.update.fetch_online_metadata")
+    def test_get_online_version_returns_version(self, mock_fetch):
+        """Test extracting online version from metadata."""
+        mock_fetch.return_value = {"distributions": [{"version": "2.1.0"}]}
+
+        online_version = _get_online_version()
+
+        assert online_version == packaging.version.parse("2.1.0")
+
+    @patch("ViroConstrictor.update.fetch_online_metadata")
+    def test_get_online_version_no_metadata(self, mock_fetch):
+        """Test online version extraction when metadata is unavailable."""
+        mock_fetch.return_value = None
+
+        online_version = _get_online_version()
+
+        assert online_version is None
+
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update.subprocess.run")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_run_update_requires_conda_prefix(self, mock_subprocess, mock_log):
+        """Test update run fails gracefully without CONDA_PREFIX."""
+        result = _run_update(packaging.version.parse("2.0.0"))
+
+        assert result is False
+        assert mock_subprocess.call_count == 1  # pip uninstall only
+        mock_log.error.assert_called_once()
+
+    @patch("ViroConstrictor.update.subprocess.run")
+    @patch("ViroConstrictor.update._build_update_cmd")
+    @patch.dict(os.environ, {"CONDA_PREFIX": "/opt/conda"}, clear=True)
+    def test_run_update_success(self, mock_build_cmd, mock_subprocess):
+        """Test successful update command execution."""
+        mock_build_cmd.return_value = ["mamba", "install"]
+        mock_subprocess.side_effect = [
+            Mock(returncode=0),
+            Mock(returncode=0, stderr=""),
+        ]
+
+        result = _run_update(packaging.version.parse("2.0.0"))
+
+        assert result is True
+        assert mock_subprocess.call_count == 2
+
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update.subprocess.run")
+    @patch("ViroConstrictor.update._build_update_cmd")
+    @patch.dict(os.environ, {"CONDA_PREFIX": "/opt/conda"}, clear=True)
+    def test_run_update_failure_logs_stderr(self, mock_build_cmd, mock_subprocess, mock_log):
+        """Test failed update command logs stderr."""
+        mock_build_cmd.return_value = ["mamba", "install"]
+        mock_subprocess.side_effect = [
+            Mock(returncode=0),
+            Mock(returncode=1, stderr="solver failed"),
+        ]
+
+        result = _run_update(packaging.version.parse("2.0.0"))
+
+        assert result is False
+        mock_log.error.assert_called_once()
+
+    @patch("ViroConstrictor.update._get_online_version")
+    @patch("ViroConstrictor.update.AskPrompts")
+    def test_prompt_for_update_accepts(self, mock_ask, mock_online_version):
+        """Test prompting user for update acceptance."""
+        mock_online_version.return_value = packaging.version.parse("2.0.0")
+        mock_ask.return_value = "yes"
+
+        result = _prompt_for_update(packaging.version.parse("1.0.0"))
+
+        assert result == packaging.version.parse("2.0.0")
+
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update._get_online_version")
+    @patch("ViroConstrictor.update.AskPrompts")
+    def test_prompt_for_update_declines(self, mock_ask, mock_online_version, mock_log):
+        """Test prompting user for update decline."""
+        mock_online_version.return_value = packaging.version.parse("2.0.0")
+        mock_ask.return_value = "no"
+
+        result = _prompt_for_update(packaging.version.parse("1.0.0"))
+
+        assert result is None
+        mock_log.info.assert_called_once_with("Skipping update to version: [bold yellow]2.0.0[/bold yellow]")
 
 
 class TestUpdate:
     """Test the main update function."""
 
-    def create_mock_config(self, auto_update="no", ask_for_update="yes"):
-        """Create a mock configuration object."""
-        config = Mock(spec=configparser.ConfigParser)
-        config.__getitem__ = Mock(return_value={"auto_update": auto_update, "ask_for_update": ask_for_update})
-        return config
-
-    def create_mock_metadata(self, version="2.0.0"):
-        """Create mock online metadata."""
-        return {"distributions": [{"version": version}]}
-
     @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    def test_update_auto_continue_no_update_needed(self, mock_fetch):
-        """Test auto-update when no update is needed."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("1.0.0")
+    @patch("ViroConstrictor.update._update_if_available")
+    def test_update_auto_continue_calls_update_if_available(self, mock_update_if_available):
+        """Test auto-update delegates to _update_if_available."""
+        config = _build_config(auto_update="yes", ask_for_update="yes")
 
         update(["viroconstrictor"], config)
 
-        mock_fetch.assert_called_once()
-
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.mamba_install")
-    @patch("ViroConstrictor.update.post_install")
-    @patch("ViroConstrictor.update.log")
-    def test_update_auto_continue_successful_update(self, mock_log, mock_post_install, mock_mamba, mock_fetch):
-        """Test successful auto-update."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_mamba.return_value = True
-
-        sysargs = ["viroconstrictor", "--input", "data/"]
-        update(sysargs, config)
-
-        mock_fetch.assert_called_once()
-        mock_log.info.assert_called()
-        mock_mamba.assert_called_once()
-        mock_post_install.assert_called_once_with(sysargs, packaging.version.parse("2.0.0"))
-
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.mamba_install")
-    @patch("ViroConstrictor.update.log")
-    def test_update_auto_continue_failed_update(self, mock_log, mock_mamba, mock_fetch):
-        """Test failed auto-update."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_mamba.return_value = False
-
-        update(["viroconstrictor"], config)
-
-        mock_fetch.assert_called_once()
-        mock_mamba.assert_called_once()
-        # Should not call post_install on failure
-
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.mamba_install")
-    @patch("ViroConstrictor.update.log")
-    def test_update_auto_continue_mamba_exception(self, mock_log, mock_mamba, mock_fetch):
-        """Test auto-update with mamba exception."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_mamba.side_effect = Exception("Mamba failed")
-
-        update(["viroconstrictor"], config)
-
-        mock_fetch.assert_called_once()
-        mock_mamba.assert_called_once()
-        mock_log.error.assert_called()
-        mock_log.warning.assert_called()
-
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    def test_update_auto_continue_no_metadata(self, mock_fetch):
-        """Test auto-update when metadata fetch fails."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = None
-
-        result = update(["viroconstrictor"], config)
-
-        assert result is None
-        mock_fetch.assert_called_once()
+        mock_update_if_available.assert_called_once_with(["viroconstrictor"], packaging.version.parse("1.0.0"))
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
     def test_update_no_prompt_early_return(self):
         """Test early return when auto_update=False and ask_for_update=False."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="no")
+        config = _build_config(auto_update="no", ask_for_update="no")
 
         result = update(["viroconstrictor"], config)
 
         assert result is None
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.AskPrompts")
-    @patch("ViroConstrictor.update.mamba_install")
-    @patch("ViroConstrictor.update.post_install")
+    @patch("ViroConstrictor.update._prompt_for_update")
+    @patch("ViroConstrictor.update._run_update")
+    @patch("ViroConstrictor.update._handle_update_result")
     @patch("ViroConstrictor.update.log")
-    def test_update_prompt_user_accepts(self, mock_log, mock_post_install, mock_mamba, mock_ask, mock_fetch):
+    def test_update_prompt_user_accepts(self, mock_log, mock_handle_update_result, mock_run_update, mock_prompt_for_update):
         """Test prompted update when user accepts."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_ask.return_value = "yes"
-        mock_mamba.return_value = True
+        config = _build_config(auto_update="no", ask_for_update="yes")
+        mock_prompt_for_update.return_value = packaging.version.parse("2.0.0")
+        mock_run_update.return_value = True
 
         sysargs = ["viroconstrictor", "--input", "data/"]
         update(sysargs, config)
 
-        mock_fetch.assert_called_once()
-        mock_ask.assert_called_once()
-        mock_log.info.assert_called()
-        mock_mamba.assert_called_once()
-        mock_post_install.assert_called_once_with(sysargs, packaging.version.parse("2.0.0"))
+        mock_prompt_for_update.assert_called_once_with(packaging.version.parse("1.0.0"))
+        mock_run_update.assert_called_once_with(packaging.version.parse("2.0.0"))
+        mock_handle_update_result.assert_called_once_with(sysargs, packaging.version.parse("2.0.0"), True)
+        mock_log.info.assert_called_once_with("Updating ViroConstrictor to latest version: [bold yellow]2.0.0[/bold yellow]")
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.AskPrompts")
-    @patch("ViroConstrictor.update.log")
-    def test_update_prompt_user_declines(self, mock_log, mock_ask, mock_fetch):
+    @patch("ViroConstrictor.update._prompt_for_update")
+    @patch("ViroConstrictor.update._run_update")
+    def test_update_prompt_user_declines(self, mock_run_update, mock_prompt_for_update):
         """Test prompted update when user declines."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_ask.return_value = "no"
+        config = _build_config(auto_update="no", ask_for_update="yes")
+        mock_prompt_for_update.return_value = None
 
         update(["viroconstrictor"], config)
 
-        mock_fetch.assert_called_once()
-        mock_ask.assert_called_once()
-        mock_log.info.assert_called_with("Skipping update to version: [bold yellow]2.0.0[/bold yellow]")
-
-    @patch("ViroConstrictor.update.__version__", "2.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    def test_update_prompt_no_update_needed(self, mock_fetch):
-        """Test prompted update when no update is needed."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-
-        result = update(["viroconstrictor"], config)
-
-        assert result is None
-        mock_fetch.assert_called_once()
+        mock_prompt_for_update.assert_called_once()
+        mock_run_update.assert_not_called()
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    def test_update_prompt_no_metadata(self, mock_fetch):
-        """Test prompted update when metadata fetch fails."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="yes")
-        mock_fetch.return_value = None
-
-        result = update(["viroconstrictor"], config)
-
-        assert result is None
-        mock_fetch.assert_called_once()
-
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.AskPrompts")
-    @patch("ViroConstrictor.update.mamba_install")
+    @patch("ViroConstrictor.update._prompt_for_update")
+    @patch("ViroConstrictor.update._run_update")
     @patch("ViroConstrictor.update.log")
-    def test_update_prompt_mamba_exception(self, mock_log, mock_mamba, mock_ask, mock_fetch):
-        """Test prompted update with mamba exception."""
-        config = self.create_mock_config(auto_update="no", ask_for_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_ask.return_value = "yes"
-        mock_mamba.side_effect = Exception("Mamba failed")
+    def test_update_prompt_run_exception(self, mock_log, mock_run_update, mock_prompt_for_update):
+        """Test prompted update with solver exception."""
+        config = _build_config(auto_update="no", ask_for_update="yes")
+        mock_prompt_for_update.return_value = packaging.version.parse("2.0.0")
+        mock_run_update.side_effect = Exception("solver failed")
 
         update(["viroconstrictor"], config)
 
-        mock_fetch.assert_called_once()
-        mock_ask.assert_called_once()
-        mock_mamba.assert_called_once()
+        mock_prompt_for_update.assert_called_once()
+        mock_run_update.assert_called_once_with(packaging.version.parse("2.0.0"))
         mock_log.error.assert_called()
         mock_log.warning.assert_called()
 
-    def test_version_comparison_logic(self):
-        """Test that packaging.version comparison works correctly."""
-        # Test basic version comparison
-        v1 = packaging.version.parse("1.0.0")
-        v2 = packaging.version.parse("2.0.0")
-        v3 = packaging.version.parse("1.0.1")
-
-        assert v1 < v2
-        assert v1 < v3
-        assert v2 > v1
-        assert v3 > v1
-        assert v1 == packaging.version.parse("1.0.0")
-
-    @patch.dict(os.environ, {"CONDA_PREFIX": "/opt/conda"})
-    @patch("ViroConstrictor.update.__prog__", "ViroConstrictor")
-    @patch("ViroConstrictor.update.__version__", "1.0.0")
-    @patch("ViroConstrictor.update.fetch_online_metadata")
-    @patch("ViroConstrictor.update.mamba_install")
     @patch("ViroConstrictor.update.post_install")
-    def test_mamba_install_parameters(self, mock_post_install, mock_mamba, mock_fetch):
-        """Test that mamba_install is called with correct parameters."""
-        config = self.create_mock_config(auto_update="yes")
-        mock_fetch.return_value = self.create_mock_metadata("2.0.0")
-        mock_mamba.return_value = True
+    @patch("ViroConstrictor.update.log")
+    def test_handle_update_result_failure_logs_error(self, mock_log, mock_post_install):
+        """Test handling failed update result."""
+        _handle_update_result(["viroconstrictor"], packaging.version.parse("2.0.0"), False)
 
-        update(["viroconstrictor"], config)
-
-        mock_mamba.assert_called_once_with(
-            "/opt/conda",
-            ("viroconstrictor 2.0.0",),
-            ("bioconda", "conda-forge"),
-        )
+        mock_post_install.assert_not_called()
+        mock_log.error.assert_called_once()
 
 
 class TestUpdateIntegration:
@@ -289,37 +298,65 @@ class TestUpdateIntegration:
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
     @patch("ViroConstrictor.update.request.urlopen")
-    @patch("ViroConstrictor.update.mamba_install")
+    @patch("ViroConstrictor.update._run_update")
     @patch("ViroConstrictor.update.post_install")
-    def test_full_auto_update_flow(self, mock_post_install, mock_mamba, mock_urlopen):
+    def test_full_auto_update_flow(self, mock_post_install, mock_run_update, mock_urlopen):
         """Test complete auto-update flow with real-like data."""
         # Mock successful API response
         mock_response = Mock()
         mock_response.read.return_value = json.dumps({"distributions": [{"version": "2.1.0"}]}).encode()
         mock_urlopen.return_value = mock_response
-        mock_mamba.return_value = True
+        mock_run_update.return_value = True
 
-        config = Mock(spec=configparser.ConfigParser)
-        config.__getitem__ = Mock(return_value={"auto_update": "yes", "ask_for_update": "yes"})
+        config = _build_config(auto_update="yes", ask_for_update="yes")
 
         sysargs = ["viroconstrictor", "--input", "test_data/"]
         update(sysargs, config)
 
         # Verify the complete flow
         mock_urlopen.assert_called_once()
-        mock_mamba.assert_called_once()
+        mock_run_update.assert_called_once_with(packaging.version.parse("2.1.0"))
         mock_post_install.assert_called_once_with(sysargs, packaging.version.parse("2.1.0"))
 
     def test_config_parsing_variations(self):
         """Test different configuration parsing scenarios."""
-        # Test case sensitivity
-        config1 = Mock(spec=configparser.ConfigParser)
-        config1.__getitem__ = Mock(return_value={"auto_update": "YES", "ask_for_update": "NO"})
-
-        config2 = Mock(spec=configparser.ConfigParser)
-        config2.__getitem__ = Mock(return_value={"auto_update": "false", "ask_for_update": "true"})
+        # Test case and value variations accepted by ConfigParser.getboolean
+        config1 = _build_config(auto_update="YES", ask_for_update="NO")
+        config2 = _build_config(auto_update="false", ask_for_update="true")
 
         # These should not raise exceptions when called
-        with patch("ViroConstrictor.update.fetch_online_metadata", return_value=None):
+        with patch("ViroConstrictor.update._update_if_available"):
             update(["test"], config1)
+
+        with patch("ViroConstrictor.update._prompt_for_update", return_value=None):
             update(["test"], config2)
+
+
+class TestUpdateIfAvailable:
+    """Tests for the internal _update_if_available workflow."""
+
+    @patch("ViroConstrictor.update._get_online_version")
+    @patch("ViroConstrictor.update._run_update")
+    @patch("ViroConstrictor.update.post_install")
+    def test_update_if_available_success(self, mock_post_install, mock_run_update, mock_get_online):
+        """Test successful update path when online version is newer."""
+        mock_get_online.return_value = packaging.version.parse("2.0.0")
+        mock_run_update.return_value = True
+
+        _update_if_available(["viroconstrictor", "--help"], packaging.version.parse("1.0.0"))
+
+        mock_run_update.assert_called_once_with(packaging.version.parse("2.0.0"))
+        mock_post_install.assert_called_once_with(["viroconstrictor", "--help"], packaging.version.parse("2.0.0"))
+
+    @patch("ViroConstrictor.update.log")
+    @patch("ViroConstrictor.update._get_online_version")
+    @patch("ViroConstrictor.update._run_update")
+    def test_update_if_available_exception(self, mock_run_update, mock_get_online, mock_log):
+        """Test exception handling in _update_if_available."""
+        mock_get_online.return_value = packaging.version.parse("2.0.0")
+        mock_run_update.side_effect = Exception("solver failed")
+
+        _update_if_available(["viroconstrictor"], packaging.version.parse("1.0.0"))
+
+        mock_log.error.assert_called_once()
+        mock_log.warning.assert_called_once()

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -9,37 +9,7 @@ from urllib.error import URLError
 import packaging.version
 import pytest
 
-from ViroConstrictor.update import fetch_online_metadata, post_install, silence_stdout_stderr, update
-
-
-class TestSilenceStdoutStderr:
-    """Test the silence_stdout_stderr context manager."""
-
-    def test_silence_stdout_stderr_context_manager(self):
-        """Test that stdout and stderr are silenced within the context."""
-        print("Before context")
-
-        with silence_stdout_stderr():
-            print("This should be silenced")
-            sys.stderr.write("This error should be silenced\n")
-
-        print("After context")
-
-    def test_silence_stdout_stderr_exception_handling(self, capsys):
-        """Test that file descriptors are properly restored even if exception occurs."""
-        print("Before context")
-
-        with pytest.raises(ValueError):
-            with silence_stdout_stderr():
-                print("This should be silenced")
-                raise ValueError("Test exception")
-
-        print("After context")
-
-        captured = capsys.readouterr()
-        assert "Before context" in captured.out
-        assert "After context" in captured.out
-        assert "This should be silenced" not in captured.out
+from ViroConstrictor.update import fetch_online_metadata, post_install, update
 
 
 class TestFetchOnlineMetadata:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,3 +1,13 @@
+"""
+Unit tests for :mod:`ViroConstrictor.update`.
+
+This module contains unit and integration tests for the update helper
+functions and higher-level update flow. Tests cover metadata fetching,
+post-install behavior, command construction, prompting, and the overall
+update orchestration. Network and subprocess interactions are mocked
+where appropriate to keep tests hermetic.
+"""
+
 import configparser
 import json
 import os
@@ -29,11 +39,22 @@ def _build_config(auto_update: str = "no", ask_for_update: str = "no") -> config
 
 
 class TestFetchOnlineMetadata:
-    """Test the fetch_online_metadata function."""
+    """Tests for :func:`ViroConstrictor.update.fetch_online_metadata`.
+
+    Validate that remote metadata is parsed correctly and that
+    connection and JSON decoding errors are handled as expected.
+    """
 
     @patch("ViroConstrictor.update.request.urlopen")
     def test_fetch_online_metadata_success(self, mock_urlopen):
-        """Test successful metadata fetch."""
+        """Return parsed metadata when the API responds successfully.
+
+        Parameters
+        ----------
+        mock_urlopen : unittest.mock.Mock
+            Mock of ``request.urlopen`` that returns a response whose
+            ``read()`` method yields a JSON payload.
+        """
         mock_response = Mock()
         mock_response.read.return_value = b'{"version": "1.0.0", "distributions": []}'
         mock_urlopen.return_value = mock_response
@@ -46,7 +67,15 @@ class TestFetchOnlineMetadata:
     @patch("ViroConstrictor.update.request.urlopen")
     @patch("ViroConstrictor.update.log")
     def test_fetch_online_metadata_connection_error(self, mock_log, mock_urlopen):
-        """Test metadata fetch with connection error."""
+        """Return ``None`` and log a warning when connection fails.
+
+        Parameters
+        ----------
+        mock_log : unittest.mock.Mock
+            Mock logger to assert that a warning was emitted.
+        mock_urlopen : unittest.mock.Mock
+            Mock configured to raise an exception on call.
+        """
         mock_urlopen.side_effect = Exception("Connection failed")
 
         result = fetch_online_metadata()
@@ -58,7 +87,15 @@ class TestFetchOnlineMetadata:
     @patch("ViroConstrictor.update.request.urlopen")
     @patch("ViroConstrictor.update.log")
     def test_fetch_online_metadata_json_error(self, mock_log, mock_urlopen):
-        """Test metadata fetch with invalid JSON."""
+        """Raise ``JSONDecodeError`` when API returns invalid JSON.
+
+        Parameters
+        ----------
+        mock_log : unittest.mock.Mock
+            Mock logger (not asserted in this test).
+        mock_urlopen : unittest.mock.Mock
+            Mock returning invalid JSON bytes.
+        """
         mock_response = Mock()
         mock_response.read.return_value = b"invalid json"
         mock_urlopen.return_value = mock_response
@@ -68,14 +105,30 @@ class TestFetchOnlineMetadata:
 
 
 class TestPostInstall:
-    """Test the post_install function."""
+    """Tests for :func:`ViroConstrictor.update.post_install`.
+
+    Verify that the updated executable is executed when present and
+    that a missing executable results in an error/exit.
+    """
 
     @patch("ViroConstrictor.update.log")
     @patch("ViroConstrictor.update.os.execv")
     @patch("ViroConstrictor.update.shutil.which")
     @patch("ViroConstrictor.update.sys.exit")
     def test_post_install_execution(self, mock_exit, mock_which, mock_execv, mock_log):
-        """Test post-install execution flow."""
+        """Invoke ``os.execv`` with the updated executable path.
+
+        Parameters
+        ----------
+        mock_exit : unittest.mock.Mock
+            Mock for ``sys.exit`` to ensure it is not called.
+        mock_which : unittest.mock.Mock
+            Mock for ``shutil.which`` returning the executable path.
+        mock_execv : unittest.mock.Mock
+            Mock for ``os.execv`` to observe invocation.
+        mock_log : unittest.mock.Mock
+            Mock logger to assert info logging.
+        """
         sysargs = ["viroconstrictor", "--input", "data/"]
         version = packaging.version.parse("2.0.0")
         mock_which.return_value = "/opt/conda/bin/viroconstrictor"
@@ -93,7 +146,17 @@ class TestPostInstall:
     @patch("ViroConstrictor.update.os.execv")
     @patch("ViroConstrictor.update.shutil.which")
     def test_post_install_missing_binary(self, mock_which, mock_execv, mock_log):
-        """Test post-install exits when executable is missing."""
+        """Raise ``SystemExit`` and log error if executable missing.
+
+        Parameters
+        ----------
+        mock_which : unittest.mock.Mock
+            Mock for ``shutil.which`` returning ``None``.
+        mock_execv : unittest.mock.Mock
+            Mock for ``os.execv`` (should not be called).
+        mock_log : unittest.mock.Mock
+            Mock logger to assert error logging.
+        """
         mock_which.return_value = None
 
         with pytest.raises(SystemExit):
@@ -104,11 +167,21 @@ class TestPostInstall:
 
 
 class TestHelperFunctions:
-    """Test update helper functions."""
+    """Tests for helper utilities in the update module.
+
+    This class covers command construction and lightweight helpers used
+    by the update runner.
+    """
 
     @patch("ViroConstrictor.update.shutil.which")
     def test_build_update_cmd_prefers_mamba(self, mock_which):
-        """Test update command prefers mamba when available."""
+        """Prefer ``mamba`` when available for building the install command.
+
+        Parameters
+        ----------
+        mock_which : unittest.mock.Mock
+            Mock for ``shutil.which`` returning the path to ``mamba``.
+        """
         mock_which.return_value = "/usr/bin/mamba"
 
         cmd = _build_update_cmd(packaging.version.parse("2.0.0"), "/opt/conda")
@@ -118,7 +191,13 @@ class TestHelperFunctions:
 
     @patch("ViroConstrictor.update.shutil.which")
     def test_build_update_cmd_falls_back_to_conda(self, mock_which):
-        """Test update command falls back to conda when mamba is unavailable."""
+        """Fall back to ``conda`` when ``mamba`` is not present.
+
+        Parameters
+        ----------
+        mock_which : unittest.mock.Mock
+            Mock for ``shutil.which`` returning ``None``.
+        """
         mock_which.return_value = None
 
         cmd = _build_update_cmd(packaging.version.parse("2.0.0"), "/opt/conda")
@@ -127,7 +206,14 @@ class TestHelperFunctions:
 
     @patch("ViroConstrictor.update.fetch_online_metadata")
     def test_get_online_version_returns_version(self, mock_fetch):
-        """Test extracting online version from metadata."""
+        """Return a parsed :class:`packaging.version.Version` from metadata.
+
+        Parameters
+        ----------
+        mock_fetch : unittest.mock.Mock
+            Mock of ``fetch_online_metadata`` returning distributions
+            including a version string.
+        """
         mock_fetch.return_value = {"distributions": [{"version": "2.1.0"}]}
 
         online_version = _get_online_version()
@@ -136,7 +222,13 @@ class TestHelperFunctions:
 
     @patch("ViroConstrictor.update.fetch_online_metadata")
     def test_get_online_version_no_metadata(self, mock_fetch):
-        """Test online version extraction when metadata is unavailable."""
+        """Return ``None`` when no metadata could be fetched.
+
+        Parameters
+        ----------
+        mock_fetch : unittest.mock.Mock
+            Mock of ``fetch_online_metadata`` returning ``None``.
+        """
         mock_fetch.return_value = None
 
         online_version = _get_online_version()
@@ -147,7 +239,15 @@ class TestHelperFunctions:
     @patch("ViroConstrictor.update.subprocess.run")
     @patch.dict(os.environ, {}, clear=True)
     def test_run_update_requires_conda_prefix(self, mock_subprocess, mock_log):
-        """Test update run fails gracefully without CONDA_PREFIX."""
+        """Return ``False`` and log an error when ``CONDA_PREFIX`` is unset.
+
+        Parameters
+        ----------
+        mock_subprocess : unittest.mock.Mock
+            Mock for ``subprocess.run``.
+        mock_log : unittest.mock.Mock
+            Mock logger to assert error logging.
+        """
         result = _run_update(packaging.version.parse("2.0.0"))
 
         assert result is False
@@ -158,7 +258,15 @@ class TestHelperFunctions:
     @patch("ViroConstrictor.update._build_update_cmd")
     @patch.dict(os.environ, {"CONDA_PREFIX": "/opt/conda"}, clear=True)
     def test_run_update_success(self, mock_build_cmd, mock_subprocess):
-        """Test successful update command execution."""
+        """Return ``True`` when both pip uninstall and package-manager steps succeed.
+
+        Parameters
+        ----------
+        mock_build_cmd : unittest.mock.Mock
+            Mock for ``_build_update_cmd`` returning package-manager args.
+        mock_subprocess : unittest.mock.Mock
+            Mock for ``subprocess.run`` returning successful codes.
+        """
         mock_build_cmd.return_value = ["mamba", "install"]
         mock_subprocess.side_effect = [
             Mock(returncode=0),
@@ -175,7 +283,17 @@ class TestHelperFunctions:
     @patch("ViroConstrictor.update._build_update_cmd")
     @patch.dict(os.environ, {"CONDA_PREFIX": "/opt/conda"}, clear=True)
     def test_run_update_failure_logs_stderr(self, mock_build_cmd, mock_subprocess, mock_log):
-        """Test failed update command logs stderr."""
+        """Log package-manager stderr and return ``False`` on failure.
+
+        Parameters
+        ----------
+        mock_build_cmd : unittest.mock.Mock
+            Mock for command builder.
+        mock_subprocess : unittest.mock.Mock
+            Mock for ``subprocess.run`` simulating failure with ``stderr``.
+        mock_log : unittest.mock.Mock
+            Mock logger to assert an error was emitted.
+        """
         mock_build_cmd.return_value = ["mamba", "install"]
         mock_subprocess.side_effect = [
             Mock(returncode=0),
@@ -190,7 +308,15 @@ class TestHelperFunctions:
     @patch("ViroConstrictor.update._get_online_version")
     @patch("ViroConstrictor.update.AskPrompts")
     def test_prompt_for_update_accepts(self, mock_ask, mock_online_version):
-        """Test prompting user for update acceptance."""
+        """Return the online version when the user accepts the prompt.
+
+        Parameters
+        ----------
+        mock_ask : unittest.mock.Mock
+            Mock for prompt helper returning ``"yes"``.
+        mock_online_version : unittest.mock.Mock
+            Mock for ``_get_online_version`` returning a newer version.
+        """
         mock_online_version.return_value = packaging.version.parse("2.0.0")
         mock_ask.return_value = "yes"
 
@@ -202,7 +328,17 @@ class TestHelperFunctions:
     @patch("ViroConstrictor.update._get_online_version")
     @patch("ViroConstrictor.update.AskPrompts")
     def test_prompt_for_update_declines(self, mock_ask, mock_online_version, mock_log):
-        """Test prompting user for update decline."""
+        """Return ``None`` and log an informational message when declined.
+
+        Parameters
+        ----------
+        mock_ask : unittest.mock.Mock
+            Mock for prompt helper returning ``"no"``.
+        mock_online_version : unittest.mock.Mock
+            Mock for ``_get_online_version`` returning a newer version.
+        mock_log : unittest.mock.Mock
+            Mock logger to assert info logging.
+        """
         mock_online_version.return_value = packaging.version.parse("2.0.0")
         mock_ask.return_value = "no"
 
@@ -213,12 +349,22 @@ class TestHelperFunctions:
 
 
 class TestUpdate:
-    """Test the main update function."""
+    """Tests for the top-level :func:`ViroConstrictor.update.update`.
+
+    Validate control flow depending on configuration flags and ensure
+    helper functions are invoked correctly.
+    """
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
     @patch("ViroConstrictor.update._update_if_available")
     def test_update_auto_continue_calls_update_if_available(self, mock_update_if_available):
-        """Test auto-update delegates to _update_if_available."""
+        """Delegate to ``_update_if_available`` when auto-update enabled.
+
+        Parameters
+        ----------
+        mock_update_if_available : unittest.mock.Mock
+            Mock for the internal update function.
+        """
         config = _build_config(auto_update="yes", ask_for_update="yes")
 
         update(["viroconstrictor"], config)
@@ -227,7 +373,10 @@ class TestUpdate:
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
     def test_update_no_prompt_early_return(self):
-        """Test early return when auto_update=False and ask_for_update=False."""
+        """Return ``None`` when both auto-update and prompts are disabled.
+
+        This ensures ``update`` is a no-op for users who opted out.
+        """
         config = _build_config(auto_update="no", ask_for_update="no")
 
         result = update(["viroconstrictor"], config)
@@ -240,7 +389,19 @@ class TestUpdate:
     @patch("ViroConstrictor.update._handle_update_result")
     @patch("ViroConstrictor.update.log")
     def test_update_prompt_user_accepts(self, mock_log, mock_handle_update_result, mock_run_update, mock_prompt_for_update):
-        """Test prompted update when user accepts."""
+        """Run update and handle its result when user accepts prompt.
+
+        Parameters
+        ----------
+        mock_log : unittest.mock.Mock
+            Mock logger used to assert the informational message.
+        mock_handle_update_result : unittest.mock.Mock
+            Mock for handling the result after update run.
+        mock_run_update : unittest.mock.Mock
+            Mock that simulates successful update execution.
+        mock_prompt_for_update : unittest.mock.Mock
+            Mock returning the online version selected for update.
+        """
         config = _build_config(auto_update="no", ask_for_update="yes")
         mock_prompt_for_update.return_value = packaging.version.parse("2.0.0")
         mock_run_update.return_value = True
@@ -257,7 +418,15 @@ class TestUpdate:
     @patch("ViroConstrictor.update._prompt_for_update")
     @patch("ViroConstrictor.update._run_update")
     def test_update_prompt_user_declines(self, mock_run_update, mock_prompt_for_update):
-        """Test prompted update when user declines."""
+        """Do not run the update when the prompt returns ``None``.
+
+        Parameters
+        ----------
+        mock_run_update : unittest.mock.Mock
+            Mock for the update runner (should not be invoked).
+        mock_prompt_for_update : unittest.mock.Mock
+            Mock returning ``None`` to indicate user declined.
+        """
         config = _build_config(auto_update="no", ask_for_update="yes")
         mock_prompt_for_update.return_value = None
 
@@ -271,7 +440,17 @@ class TestUpdate:
     @patch("ViroConstrictor.update._run_update")
     @patch("ViroConstrictor.update.log")
     def test_update_prompt_run_exception(self, mock_log, mock_run_update, mock_prompt_for_update):
-        """Test prompted update with solver exception."""
+        """Log error and warning when the update runner raises an exception.
+
+        Parameters
+        ----------
+        mock_log : unittest.mock.Mock
+            Mock logger to assert error/warning were emitted.
+        mock_run_update : unittest.mock.Mock
+            Mock that raises to simulate failure.
+        mock_prompt_for_update : unittest.mock.Mock
+            Mock returning the online version to attempt update.
+        """
         config = _build_config(auto_update="no", ask_for_update="yes")
         mock_prompt_for_update.return_value = packaging.version.parse("2.0.0")
         mock_run_update.side_effect = Exception("solver failed")
@@ -286,7 +465,15 @@ class TestUpdate:
     @patch("ViroConstrictor.update.post_install")
     @patch("ViroConstrictor.update.log")
     def test_handle_update_result_failure_logs_error(self, mock_log, mock_post_install):
-        """Test handling failed update result."""
+        """Do not call post-install and log an error on failure.
+
+        Parameters
+        ----------
+        mock_log : unittest.mock.Mock
+            Mock logger to assert error logging.
+        mock_post_install : unittest.mock.Mock
+            Mock for post-install which should not be called on failure.
+        """
         _handle_update_result(["viroconstrictor"], packaging.version.parse("2.0.0"), False)
 
         mock_post_install.assert_not_called()
@@ -294,14 +481,29 @@ class TestUpdate:
 
 
 class TestUpdateIntegration:
-    """Integration tests for the update module."""
+    """Integration-style tests for the update module.
+
+    These tests patch external boundaries but exercise the real
+    top-level ``update`` function to validate composed behaviour.
+    """
 
     @patch("ViroConstrictor.update.__version__", "1.0.0")
     @patch("ViroConstrictor.update.request.urlopen")
     @patch("ViroConstrictor.update._run_update")
     @patch("ViroConstrictor.update.post_install")
     def test_full_auto_update_flow(self, mock_post_install, mock_run_update, mock_urlopen):
-        """Test complete auto-update flow with real-like data."""
+        """Complete auto-update path using mocked external calls.
+
+        Parameters
+        ----------
+        mock_post_install : unittest.mock.Mock
+            Mock for the post-install handler.
+        mock_run_update : unittest.mock.Mock
+            Mock simulating a successful update run.
+        mock_urlopen : unittest.mock.Mock
+            Mock for network call returning metadata with a newer
+            distribution.
+        """
         # Mock successful API response
         mock_response = Mock()
         mock_response.read.return_value = json.dumps({"distributions": [{"version": "2.1.0"}]}).encode()
@@ -319,7 +521,11 @@ class TestUpdateIntegration:
         mock_post_install.assert_called_once_with(sysargs, packaging.version.parse("2.1.0"))
 
     def test_config_parsing_variations(self):
-        """Test different configuration parsing scenarios."""
+        """Accept multiple string representations for boolean flags.
+
+        Ensure ``update`` handles case variations like "YES"/"NO" and
+        truthy/falsey strings without raising.
+        """
         # Test case and value variations accepted by ConfigParser.getboolean
         config1 = _build_config(auto_update="YES", ask_for_update="NO")
         config2 = _build_config(auto_update="false", ask_for_update="true")
@@ -333,13 +539,27 @@ class TestUpdateIntegration:
 
 
 class TestUpdateIfAvailable:
-    """Tests for the internal _update_if_available workflow."""
+    """Tests for :func:`ViroConstrictor.update._update_if_available`.
+
+    Validate the conditional attempt to update when a newer online
+    version is detected and verify exception handling during update.
+    """
 
     @patch("ViroConstrictor.update._get_online_version")
     @patch("ViroConstrictor.update._run_update")
     @patch("ViroConstrictor.update.post_install")
     def test_update_if_available_success(self, mock_post_install, mock_run_update, mock_get_online):
-        """Test successful update path when online version is newer."""
+        """Run update and post-install when a newer version is available.
+
+        Parameters
+        ----------
+        mock_post_install : unittest.mock.Mock
+            Mock for post-install handler.
+        mock_run_update : unittest.mock.Mock
+            Mock for the update runner returning success.
+        mock_get_online : unittest.mock.Mock
+            Mock returning a newer online version.
+        """
         mock_get_online.return_value = packaging.version.parse("2.0.0")
         mock_run_update.return_value = True
 
@@ -352,7 +572,17 @@ class TestUpdateIfAvailable:
     @patch("ViroConstrictor.update._get_online_version")
     @patch("ViroConstrictor.update._run_update")
     def test_update_if_available_exception(self, mock_run_update, mock_get_online, mock_log):
-        """Test exception handling in _update_if_available."""
+        """Log error and warning when the update runner raises.
+
+        Parameters
+        ----------
+        mock_run_update : unittest.mock.Mock
+            Mock configured to raise an exception.
+        mock_get_online : unittest.mock.Mock
+            Mock returning the newer online version.
+        mock_log : unittest.mock.Mock
+            Mock logger to assert error and warning calls.
+        """
         mock_get_online.return_value = packaging.version.parse("2.0.0")
         mock_run_update.side_effect = Exception("solver failed")
 


### PR DESCRIPTION
Refactors and improves the update mechanism for ViroConstrictor, focusing on updating the package using conda or mamba, handling pip-installed versions, and ensuring an in-place replacement after installation. 
Also improves error handling and logging for better user feedback during the update process.

The process now always uses either `mamba` or `conda` with a preference of `mamba` if available for locally updating ViroConstrictor. And it uses the `--force-reinstall` flag to ensure a proper overwrite of the locally existing files, additionally we uninstall any version that was previously installed with pip to avoid any potential conflicts.

Additionally, the subprocess-based update logic has been replaced with the new ViroConstrictor executable using `os.execv`. This is an extra safety check to make sure the new process is always the updated version.

Lastly the unused import of `mamba.api.install` was removed, and `shutil` was imported to support the new update logic.