### PR TITLE
Slim container images for #161

### DIFF
--- a/containers/Alignment.dockerfile
+++ b/containers/Alignment.dockerfile
@@ -8,25 +8,13 @@ USER root
 
 ARG UID=10001
 
-# Combine apt-get commands and clean up in the same layer to reduce size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends adduser && \
-    adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Combine micromamba installs and clean in one layer
-# Added --prune to remove unused packages
-RUN micromamba install -q -y -n base git -c conda-forge && \
+RUN useradd --no-create-home --shell /sbin/nologin --uid "${UID}" appuser && \
     micromamba install -q -y -n base -f /install.yml && \
-    micromamba clean -q --all --yes
+    micromamba clean -q --all --yes && \
+    rm -rf /opt/conda/pkgs && \
+    rm -rf /opt/conda/x86_64-conda-linux-gnu && \
+    rm -rf /opt/conda/include && \
+    rm -rf /opt/conda/share/doc /opt/conda/share/man /opt/conda/share/info
 
 USER appuser
 

--- a/containers/Clean.dockerfile
+++ b/containers/Clean.dockerfile
@@ -9,25 +9,15 @@ USER root
 
 ARG UID=10001
 
-# Combine apt-get commands and clean up in the same layer to reduce size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends adduser && \
-    adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Combine micromamba installs and clean in one layer
-# Added --prune to remove unused packages
-RUN micromamba install -q -y -n base git -c conda-forge && \
+RUN useradd --no-create-home --shell /sbin/nologin --uid "${UID}" appuser && \
     micromamba install -q -y -n base -f /install.yml && \
-    micromamba clean -q --all --yes
+    micromamba clean -q --all --yes && \
+    rm -rf /opt/conda/pkgs && \
+    rm -rf /opt/conda/x86_64-conda-linux-gnu && \
+    rm -rf /opt/conda/include && \
+    rm -rf /opt/conda/share/doc /opt/conda/share/man /opt/conda/share/info && \
+    rm -f /opt/conda/lib/jvm/lib/src.zip
+
 USER appuser
 
 ENV PATH=/opt/conda/bin:$PATH

--- a/containers/ORF_analysis.dockerfile
+++ b/containers/ORF_analysis.dockerfile
@@ -8,25 +8,14 @@ USER root
 
 ARG UID=10001
 
-# Combine apt-get commands and clean up in the same layer to reduce size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends adduser && \
-    adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Combine micromamba installs and clean in one layer
-# Added --prune to remove unused packages
-RUN micromamba install -q -y -n base git -c conda-forge && \
+RUN useradd --no-create-home --shell /sbin/nologin --uid "${UID}" appuser && \
     micromamba install -q -y -n base -f /install.yml && \
-    micromamba clean -q --all --yes
+    micromamba clean -q --all --yes && \
+    rm -rf /opt/conda/pkgs && \
+    rm -rf /opt/conda/x86_64-conda-linux-gnu && \
+    rm -rf /opt/conda/include && \
+    rm -rf /opt/conda/share/doc /opt/conda/share/man /opt/conda/share/info
+
 USER appuser
 
 ENV PATH=/opt/conda/bin:$PATH

--- a/containers/core_scripts.dockerfile
+++ b/containers/core_scripts.dockerfile
@@ -8,25 +8,14 @@ USER root
 
 ARG UID=10001
 
-# Combine apt-get commands and clean up in the same layer to reduce size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends adduser && \
-    adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Combine micromamba installs and clean in one layer
-# Added --prune to remove unused packages
-RUN micromamba install -q -y -n base git -c conda-forge && \
+RUN useradd --no-create-home --shell /sbin/nologin --uid "${UID}" appuser && \
     micromamba install -q -y -n base -f /install.yml && \
-    micromamba clean -q --all --yes
+    micromamba clean -q --all --yes && \
+    rm -rf /opt/conda/pkgs && \
+    rm -rf /opt/conda/x86_64-conda-linux-gnu && \
+    rm -rf /opt/conda/include && \
+    rm -rf /opt/conda/share/doc /opt/conda/share/man /opt/conda/share/info && \
+    rm -f /opt/conda/lib/jvm/lib/src.zip
 
 USER appuser
 

--- a/containers/mr_scripts.dockerfile
+++ b/containers/mr_scripts.dockerfile
@@ -8,25 +8,14 @@ USER root
 
 ARG UID=10001
 
-# Combine apt-get commands and clean up in the same layer to reduce size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends adduser && \
-    adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    appuser && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Combine micromamba installs and clean in one layer
-# Added --prune to remove unused packages
-RUN micromamba install -q -y -n base git -c conda-forge && \
+RUN useradd --no-create-home --shell /sbin/nologin --uid "${UID}" appuser && \
     micromamba install -q -y -n base -f /install.yml && \
-    micromamba clean -q --all --yes
+    micromamba clean -q --all --yes && \
+    rm -rf /opt/conda/pkgs && \
+    rm -rf /opt/conda/x86_64-conda-linux-gnu && \
+    rm -rf /opt/conda/include && \
+    rm -rf /opt/conda/share/doc /opt/conda/share/man /opt/conda/share/info
+
 USER appuser
 
 ENV PATH=/opt/conda/bin:$PATH


### PR DESCRIPTION
Hi! Saw #161 and took a look. Conservative on purpose, only changes that can't plausibly affect runtime behaviour.

| Container    | Baseline | Slimmed | Saved |
|---|---|---|---|
| Alignment    | 1.19 GB | 377 MB  | -68% |
| Clean        | 2.83 GB | 1.97 GB | -30% |
| ORF_analysis | 786 MB  | 500 MB  | -36% |
| core_scripts | 1.38 GB | 961 MB  | -30% |
| mr_scripts   | 802 MB  | 517 MB  | -36% |
| **Total**    | 6.99 GB | 4.32 GB | **-38%** |

What's in the patch:

- `useradd` instead of `apt-get install adduser`. Same end state, drops the apt round-trip.
- Drop `micromamba install git` in the 5 envs with no `git+...` pip URL (Consensus is the only one that needs it).
- `rm -rf /opt/conda/{pkgs,x86_64-conda-linux-gnu,include}` and `share/{doc,man,info}` post-install.
- `rm -f /opt/conda/lib/jvm/lib/src.zip` on Clean and core_scripts. Source archive for IDE step-through; FastQC doesn't read it.

Through some experimentation, I found that it is possible to reduce these sizes further, but it requires cutting a bit more aggressively, and it might require introducing some additional tooling and testing. I figured I'd keep the PR here at first.

I didn't touch `Consensus.dockerfile` because it unfortunately didn't build at the time of writing due to a `gcc: No such file or directory` failure while pip-compiling biopython during the TrueConsense install. The published `.sif` may keep working because `build_containers.py:50` skips on hash match. Can file separately. Happy to split into per-container commits if easier to review.

Werner

---

Build env: Docker 29.4.0, Linux 6.18.24 x86_64, base `mambaorg/micromamba@sha256:313021a575cb995a45357e26c48e7979cae278267c28e12c2ecac49c35729c8b` (2026-03-23), branch HEAD `7ea603a`, date 2026-05-03. Reproduce:

```sh
for c in Alignment Clean ORF_analysis core_scripts mr_scripts; do
  docker build -f "containers/${c}.dockerfile" -t "viro-${c,,}:upstream" .  # from upstream main
done
# repeat on this branch, tag :slim
docker images --format "{{.Repository}}:{{.Tag}} {{.Size}}" | grep "^viro-" | sort
```
