### PR TITLE
fix(scheduler): pass executor_settings when dispatching SLURM jobs

### DIFF
--- a/ViroConstrictor/workflow_executor.py
+++ b/ViroConstrictor/workflow_executor.py
@@ -12,6 +12,14 @@ from ViroConstrictor.scheduler import Scheduler
 from ViroConstrictor.workflow_config import WorkflowConfig
 
 
+def _executor_settings_for(scheduler: Scheduler) -> Any:
+    """ExecutorSettings instance for the SLURM plugin, None for the rest."""
+    if scheduler is Scheduler.SLURM:
+        from snakemake_executor_plugin_slurm import ExecutorSettings as SlurmExecutorSettings
+        return SlurmExecutorSettings()
+    return None
+
+
 def _patch_debugger_for_snakemake() -> None:
     # gettrace returns something only if debugger is active
     if sys.gettrace() is None:
@@ -108,6 +116,7 @@ class WorkflowExecutor:
 
             self.dag_api.execute_workflow(
                 executor=scheduler.value[0],
+                executor_settings=_executor_settings_for(scheduler),
                 execution_settings=self.workflow_config.execution_settings,
                 remote_execution_settings=self.workflow_config.remote_execution_settings,
                 scheduling_settings=self.workflow_config.scheduling_settings,

--- a/tests/unit/test_workflow_executor_settings.py
+++ b/tests/unit/test_workflow_executor_settings.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+import pytest
+
+from ViroConstrictor.scheduler import Scheduler
+
+
+class TestExecutorSettingsFor:
+
+    @pytest.mark.parametrize(
+        "scheduler",
+        [Scheduler.LOCAL, Scheduler.DRYRUN, Scheduler.LSF],
+    )
+    def test_returns_none_for_in_process_or_unhandled(self, scheduler):
+        from ViroConstrictor.workflow_executor import _executor_settings_for
+
+        assert _executor_settings_for(scheduler) is None
+
+    def test_returns_slurm_executor_settings(self):
+        slurm_module = pytest.importorskip("snakemake_executor_plugin_slurm")
+        from ViroConstrictor.workflow_executor import _executor_settings_for
+
+        settings = _executor_settings_for(Scheduler.SLURM)
+        assert isinstance(settings, slurm_module.ExecutorSettings)
+        assert hasattr(settings, "logdir")
+        assert hasattr(settings, "partition_config")
+
+
+class TestWorkflowExecutorPassesSettings:
+    """WorkflowExecutor must forward executor_settings into execute_workflow."""
+
+    def _run_executor(self, scheduler):
+        """Run WorkflowExecutor against a mocked SnakemakeApi, return the execute_workflow call args."""
+        from ViroConstrictor.workflow_executor import WorkflowExecutor
+
+        with mock.patch("ViroConstrictor.workflow_executor.SnakemakeApi") as api_cls:
+            api_ctx = api_cls.return_value.__enter__.return_value
+            dag_api = api_ctx.workflow.return_value.dag.return_value
+
+            WorkflowExecutor(
+                parsed_input=mock.MagicMock(),
+                workflow_config=mock.MagicMock(),
+                scheduler=scheduler,
+            )
+
+            return dag_api.execute_workflow.call_args
+
+    def test_slurm_forwards_non_none_executor_settings(self):
+        pytest.importorskip("snakemake_executor_plugin_slurm")
+        call = self._run_executor(Scheduler.SLURM)
+        assert call is not None, "execute_workflow was never called"
+        assert call.kwargs.get("executor_settings") is not None
+
+    def test_local_forwards_none_executor_settings(self):
+        call = self._run_executor(Scheduler.LOCAL)
+        assert call is not None
+        # Absent or explicitly None are both fine here.
+        assert call.kwargs.get("executor_settings") is None


### PR DESCRIPTION
The `scheduler = SLURM` path crashes at startup with `AttributeError: 'NoneType' object has no attribute 'logdir'` (against `snakemake-executor-plugin-slurm==2.0.0`, what `env.yml` pins). The plugin reads `executor_settings.logdir` during init; `WorkflowExecutor` calls `dag_api.execute_workflow` without an `executor_settings=` kwarg, so it stays `None`.

Fix: helper `_executor_settings_for(scheduler)` returning `SlurmExecutorSettings()` for SLURM and `None` otherwise. Lazy import so machines without the SLURM plugin still run.

Regression test asserts `WorkflowExecutor` passes a non-`None` `executor_settings` for SLURM; fails pre-fix. Tangentially addresses the `workflow_config.py:359` TODO.
