### PR TITLE
fix(amplicon_covs): iterate amplicons in genomic order, not label order

### DIFF
--- a/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
+++ b/ViroConstrictor/workflow/main/scripts/amplicon_covs.py
@@ -364,7 +364,12 @@ class AmpliconCovs(BaseScript):
         amplicon_numbers = sorted(primers["count"].unique())
         df = pd.DataFrame(amplicon_numbers, columns=["amplicon_number"])
 
-        for idx, amplicon_number in enumerate(amplicon_numbers):
+        # Walk amplicons in genomic order, not numeric label order: a BED file may
+        # number amplicons independently of their position on the reference, and the
+        # previous/next lookups below need to refer to genomic neighbours.
+        genomic_order = list(primers.groupby("count")[1].min().sort_values().index)
+
+        for g_idx, amplicon_number in enumerate(genomic_order):
             amplicon_group = primers[primers["count"] == amplicon_number]
 
             # Get forward (LEFT) and reverse (RIGHT) primers for this amplicon
@@ -372,15 +377,15 @@ class AmpliconCovs(BaseScript):
             reverse_primers = amplicon_group[amplicon_group["direction"] == ReadDirection.REVERSE]
 
             # Determine start position
-            if idx == 0:
-                # First amplicon: start at end of own LEFT primer
+            if g_idx == 0:
+                # Genomic-first amplicon: start at end of own LEFT primer
                 if not forward_primers.empty:
                     amplicon_start = forward_primers[2].max()  # Column 2 is the end position
                 else:
                     amplicon_start = amplicon_group[1].min()
             else:
-                # Subsequent amplicons: start at end of previous amplicon's RIGHT primer
-                prev_amplicon_number = amplicon_numbers[idx - 1]
+                # Subsequent amplicons: start at end of previous (in genomic order) amplicon's RIGHT primer
+                prev_amplicon_number = genomic_order[g_idx - 1]
                 prev_amplicon_group = primers[primers["count"] == prev_amplicon_number]
                 prev_reverse_primers = prev_amplicon_group[prev_amplicon_group["direction"] == ReadDirection.REVERSE]
 
@@ -391,15 +396,15 @@ class AmpliconCovs(BaseScript):
                     amplicon_start = forward_primers[2].max() if not forward_primers.empty else amplicon_group[1].min()
 
             # Determine end position
-            if idx == len(amplicon_numbers) - 1:
-                # Last amplicon: end at start of own RIGHT primer
+            if g_idx == len(genomic_order) - 1:
+                # Genomic-last amplicon: end at start of own RIGHT primer
                 if not reverse_primers.empty:
                     amplicon_end = reverse_primers[1].min()  # Column 1 is the start position
                 else:
                     amplicon_end = amplicon_group[2].max()
             else:
-                # Non-last amplicons: end at start of next amplicon's LEFT primer
-                next_amplicon_number = amplicon_numbers[idx + 1]
+                # Non-last amplicons: end at start of next (in genomic order) amplicon's LEFT primer
+                next_amplicon_number = genomic_order[g_idx + 1]
                 next_amplicon_group = primers[primers["count"] == next_amplicon_number]
                 next_forward_primers = next_amplicon_group[next_amplicon_group["direction"] == ReadDirection.FORWARD]
 

--- a/tests/unit/scripts/test_amplicon_covs.py
+++ b/tests/unit/scripts/test_amplicon_covs.py
@@ -261,6 +261,83 @@ def test_calculate_amplicon_start_end_two_amplicons(tmp_path: Path) -> None:
     assert (second["start"], second["end"]) == (90, 170)
 
 
+def test_calculate_amplicon_start_end_non_genomic_numbering(tmp_path: Path) -> None:
+    """
+    Regression test for #198: amplicon coordinates must be computed correctly
+    when numeric amplicon order in the BED file does not match genomic order
+    (e.g. amplicon 1 lies downstream of amplicon 2 on the reference).
+
+    Returns
+    -------
+    None
+    """
+
+    # Amplicon 1 at ref pos ~5000-5100, amplicon 2 at ref pos ~100-200.
+    # Sorting by amplicon number (1, 2) does NOT match genomic order (2, 1).
+    bed_lines = [
+        "NC_000.1\t5000\t5010\tvirus_1_LEFT\t0\t+\n",
+        "NC_000.1\t5090\t5100\tvirus_1_RIGHT\t0\t-\n",
+        "NC_000.1\t100\t110\tvirus_2_LEFT\t0\t+\n",
+        "NC_000.1\t190\t200\tvirus_2_RIGHT\t0\t-\n",
+    ]
+    bed_path = _write_bed(tmp_path, bed_lines)
+    primers = AmpliconCovs._open_tsv_file(bed_path)
+    covs = AmpliconCovs(input=bed_path, coverages=bed_path, key="sample", output=bed_path)
+    primers = covs._split_primer_names(primers)
+
+    amplicon_sizes = covs._calculate_amplicon_start_end(primers)
+
+    first_by_number = amplicon_sizes.loc[amplicon_sizes["amplicon_number"] == 1].iloc[0]
+    second_by_number = amplicon_sizes.loc[amplicon_sizes["amplicon_number"] == 2].iloc[0]
+
+    # Each amplicon's region must be a valid interval within its own primer span.
+    assert first_by_number["start"] < first_by_number["end"]
+    assert second_by_number["start"] < second_by_number["end"]
+
+    # Amplicon 2 is genomic-first: start at own LEFT end, end at next-in-genomic-order's LEFT start.
+    assert (second_by_number["start"], second_by_number["end"]) == (110, 5000)
+    # Amplicon 1 is genomic-last: start at prev-in-genomic-order's RIGHT end, end at own RIGHT start.
+    assert (first_by_number["start"], first_by_number["end"]) == (200, 5090)
+
+
+def test_calculate_amplicon_start_end_three_amplicons_scrambled(tmp_path: Path) -> None:
+    """
+    Regression test for #198 with three amplicons in scrambled label order, so
+    the middle amplicon exercises both the previous- and next-neighbour lookups
+    in genomic order (the two-amplicon case only hits the boundary branches).
+
+    Genomic order is amplicon 2 (~100), amplicon 3 (~3000), amplicon 1 (~7000).
+
+    Returns
+    -------
+    None
+    """
+
+    bed_lines = [
+        "NC_000.1\t7000\t7010\tvirus_1_LEFT\t0\t+\n",
+        "NC_000.1\t7090\t7100\tvirus_1_RIGHT\t0\t-\n",
+        "NC_000.1\t100\t110\tvirus_2_LEFT\t0\t+\n",
+        "NC_000.1\t190\t200\tvirus_2_RIGHT\t0\t-\n",
+        "NC_000.1\t3000\t3010\tvirus_3_LEFT\t0\t+\n",
+        "NC_000.1\t3190\t3200\tvirus_3_RIGHT\t0\t-\n",
+    ]
+    bed_path = _write_bed(tmp_path, bed_lines)
+    primers = AmpliconCovs._open_tsv_file(bed_path)
+    covs = AmpliconCovs(input=bed_path, coverages=bed_path, key="sample", output=bed_path)
+    primers = covs._split_primer_names(primers)
+
+    amplicon_sizes = covs._calculate_amplicon_start_end(primers)
+
+    by_n = {n: amplicon_sizes.loc[amplicon_sizes["amplicon_number"] == n].iloc[0] for n in (1, 2, 3)}
+
+    # Amplicon 2 is genomic-first.
+    assert (by_n[2]["start"], by_n[2]["end"]) == (110, 3000)
+    # Amplicon 3 is genomic-middle: start at prev (A2) RIGHT end, end at next (A1) LEFT start.
+    assert (by_n[3]["start"], by_n[3]["end"]) == (200, 7000)
+    # Amplicon 1 is genomic-last.
+    assert (by_n[1]["start"], by_n[1]["end"]) == (3200, 7090)
+
+
 def test_calculate_amplicon_start_end_invalid_raises(tmp_path: Path) -> None:
     """
     Ensure `_calculate_amplicon_start_end` raises for overlapping/invalid primer pairs.


### PR DESCRIPTION
_calculate_amplicon_start_end walked amplicons sorted by their numeric label (count) and used idx-1 / idx+1 to find the previous and next amplicon for boundary computation, implicitly assuming label order matches the order amplicons appear on the reference. On BED files where that does not hold, the neighbour lookup returned the wrong pair, the boundary positions crossed over, and the validator raised a ValueError.

Iterate in genomic order (sorted by minimum primer start) so that neighbour lookups refer to the correct amplicons. The dataframe row order is set by label-keyed df.loc writes inside the loop, so it stays label-sorted regardless of iteration order, preserving alignment with _create_amplicon_names_list downstream.

Adds two regression tests: a 2-amplicon BED with reversed labels (the exact #198 scenario) and a 3-amplicon scrambled BED that exercises the middle-of-list neighbour lookups.

Closes #198.